### PR TITLE
Us32 fix nom prenom membre

### DIFF
--- a/templates/user/show.html.twig
+++ b/templates/user/show.html.twig
@@ -22,11 +22,11 @@
                 </td>
             </tr>
             <tr>
-                <th>LastName</th>
+                <th>Nom</th>
                 <td>{{ user.lastName }}</td>
             </tr>
             <tr>
-                <th>FirstName</th>
+                <th>Prénom</th>
                 <td>{{ user.firstName }}</td>
             </tr>
         </tbody>


### PR DESCRIPTION
Les noms et prénoms qui ne sont pas affichés côté client, ne le sont pas car les champs ne sont pas renseignés en bdd (cela fera l'objet d'un autre fix concernant lui l'ajout d'un nouvel utilisateur)